### PR TITLE
Removed not used custom inline directives

### DIFF
--- a/browse/browse.component.html
+++ b/browse/browse.component.html
@@ -9,7 +9,7 @@
     <Label class="action-bar-title" text="Browse"></Label>
 </ActionBar>
 
-<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition" tkExampleTitle tkToggleNavButton>
+<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition">
     <StackLayout tkDrawerContent>
         <MyDrawer [selectedPage]="'Browse'"></MyDrawer>
     </StackLayout>

--- a/featured/featured.component.html
+++ b/featured/featured.component.html
@@ -9,7 +9,7 @@
     <Label class="action-bar-title" text="Featured"></Label>
 </ActionBar>
 
-<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition" tkExampleTitle tkToggleNavButton>
+<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition">
     <StackLayout tkDrawerContent>
         <MyDrawer [selectedPage]="'Featured'"></MyDrawer>
     </StackLayout>

--- a/home/home.component.html
+++ b/home/home.component.html
@@ -9,7 +9,7 @@
     <Label class="action-bar-title" text="Home"></Label>
 </ActionBar>
 
-<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition" tkExampleTitle tkToggleNavButton>
+<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition">
     <StackLayout tkDrawerContent>
         <MyDrawer [selectedPage]="'Home'"></MyDrawer>
     </StackLayout>

--- a/search/search.component.html
+++ b/search/search.component.html
@@ -9,7 +9,7 @@
     <Label class="action-bar-title" text="Search"></Label>
 </ActionBar>
 
-<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition" tkExampleTitle tkToggleNavButton>
+<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition">
     <StackLayout tkDrawerContent>
         <MyDrawer [selectedPage]="'Search'"></MyDrawer>
     </StackLayout>

--- a/settings/settings.component.html
+++ b/settings/settings.component.html
@@ -9,7 +9,7 @@
     <Label class="action-bar-title" text="Settings"></Label>
 </ActionBar>
 
-<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition" tkExampleTitle tkToggleNavButton>
+<RadSideDrawer #drawer showOverNavigation="true" [drawerTransition]="sideDrawerTransition">
     <StackLayout tkDrawerContent>
         <MyDrawer [selectedPage]="'Settings'"></MyDrawer>
     </StackLayout>


### PR DESCRIPTION
Hi,

I noticed that there are a few places where the `tkExampleTitle` and `tkToggleNavButton` are used. Those are custom directives that are specific only for the sdkAngular demo app located [here](https://github.com/telerik/nativescript-ui-samples-angular). Those custom directives implementation can be found [here](https://github.com/telerik/nativescript-ui-samples-angular/blob/a6e000cf89a76c52e37f937d88b8efa506d948d9/sdkAngular/app/navigation/directives/example.directive.ts) and [here](https://github.com/telerik/nativescript-ui-samples-angular/blob/a6e000cf89a76c52e37f937d88b8efa506d948d9/sdkAngular/app/navigation/directives/toggle-nav-button.directive.ts) and in the sdkAngular app they are used to show the example's title and toggle the backwards navigation button but they are **not required** by the RadSideDrawer in anyway.