### PR TITLE
Fix "Types of property 'lift' are incompatible" TS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nativescript-theme-core": "~1.0.2",
     "nativescript-telerik-ui": "^3.0.0",
     "reflect-metadata": "~0.1.8",
-    "rxjs": "~5.3.0",
+    "rxjs": "~5.4.0",
     "tns-core-modules": "~3.1.0",
     "zone.js": "~0.8.2"
   },


### PR DESCRIPTION
```
file: 'file:///d%3A/GitHub/master-detail-ng/app/cars/car-detail-edit/car-detail-edit.component.ts'
severity: 'Error'
message: 'The 'this' context of type 'BehaviorSubject<ActivatedRoute>' is not assignable to method's 'this' of type 'Observable<ActivatedRoute>'.
  Types of property 'lift' are incompatible.
    Type '<R>(operator: Operator<ActivatedRoute, R>) => Observable<ActivatedRoute>' is not assignable to type '<R>(operator: Operator<ActivatedRoute, R>) => Observable<R>'.
      Type 'Observable<ActivatedRoute>' is not assignable to type 'Observable<R>'.
        Type 'ActivatedRoute' is not assignable to type 'R'.'
at: '51,9'
source: 'ts'
```

Updating to rxjs 5.4.2 or newer seems to resolve the issue ([source](https://github.com/angular/angular/issues/17800))

Note that this error is only visible in editor, not in runtime.