### PR TITLE
Changing _selectedPage on tap to highlight it in the sidedrawer

### DIFF
--- a/app.component.ts
+++ b/app.component.ts
@@ -35,6 +35,7 @@ export class AppComponent implements OnInit {
     }
 
     onNavItemTap(navItemRoute: string): void {
+        this._selectedPage = navItemRoute.slice(1).replace(/^\w/, c => c.toUpperCase());
         this.routerExtensions.navigate([navItemRoute], {
             transition: {
                 name: "fade"


### PR DESCRIPTION
Issue: https://github.com/NativeScript/template-drawer-navigation-ng/issues/106

While navigating to different places in the side drawer, the items in the side drawer don't get highlighted and only the Home component remains highlighted.

This is because after `this._selectedPage` is initialised in `ngOnInit` method, it is never reset after a user taps on a sidedrawer item.